### PR TITLE
feat: bump workload to v1.6.0-rc.0 and update CRD to v1

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -11,7 +11,7 @@ resources:
     type: oci-image
     description: Backing OCI image
     auto-fetch: true
-    upstream-source: 'public.ecr.aws/j1r0q0g6/notebooks/admission-webhook:v1.4-rc.0'
+    upstream-source: 'docker.io/kubeflownotebookswg/poddefaults-webhook:v1.6.0-rc.0'
 provides:
   pod-defaults:
     interface: pod-defaults

--- a/src/charm.py
+++ b/src/charm.py
@@ -247,6 +247,12 @@ class AdmissionWebhookCharm(CharmBase):
                             "name": "admission-webhook",
                             "webhooks": [
                                 {
+                                    # Probably not necessary, but keeps us in sync with upstream
+                                    # which wasn't always using admissionReviewVersions/v1
+                                    "admissionReviewVersions": [
+                                        "v1beta1",
+                                        "v1",
+                                    ],
                                     "name": "admission-webhook.kubeflow.org",
                                     "failurePolicy": "Fail",
                                     "clientConfig": {

--- a/src/crds.yaml
+++ b/src/crds.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: poddefaults.kubeflow.org
@@ -9,46 +9,62 @@ spec:
     kind: PodDefault
     plural: poddefaults
     singular: poddefault
+  preserveUnknownFields: false
   scope: Namespaced
-  version: v1alpha1
-  validation:
-    openAPIV3Schema:
-      properties:
-        apiVersion:
-          type: string
-        kind:
-          type: string
-        metadata:
-          type: object
-        spec:
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
           properties:
-            desc:
+            apiVersion:
               type: string
-            serviceAccountName:
+            kind:
               type: string
-            automountServiceAccountToken:
-              type: boolean
-            env:
-              items:
-                type: object
-              type: array
-            envFrom:
-              items:
-                type: object
-              type: array
-            selector:
+            metadata:
               type: object
-            volumeMounts:
-              items:
-                type: object
-              type: array
-            volumes:
-              items:
-                type: object
-              type: array
-          required:
-            - selector
+            spec:
+              properties:
+                desc:
+                  type: string
+                serviceAccountName:
+                  type: string
+                automountServiceAccountToken:
+                  type: boolean
+                env:
+                  items:
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                  type: array
+                  x-kubernetes-preserve-unknown-fields: true
+                envFrom:
+                  items:
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                  type: array
+                  x-kubernetes-preserve-unknown-fields: true
+                selector:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                volumeMounts:
+                  items:
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                  type: array
+                  x-kubernetes-preserve-unknown-fields: true
+                volumes:
+                  items:
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                  type: array
+                  x-kubernetes-preserve-unknown-fields: true
+              required:
+                - selector
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+            status:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
           type: object
-        status:
-          type: object
-      type: object
+          x-kubernetes-preserve-unknown-fields: true


### PR DESCRIPTION
* Bumps the poddefaults-webhook image to v1.6.0-rc.0
* updates the PodDefault CustomResourceDefinition to use the v1 release of CRDs