### PR TITLE
Rescope admission-webhook's mutating webhook

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -264,29 +264,10 @@ class AdmissionWebhookCharm(CharmBase):
                                             "port": 4443,
                                         },
                                     },
-                                    "objectSelector": {
-                                        "matchExpressions": [
-                                            {
-                                                "key": "juju-app",
-                                                "operator": "NotIn",
-                                                "values": ["admission-webhook"],
-                                            },
-                                            {
-                                                "key": "app.kubernetes.io/name",
-                                                "operator": "NotIn",
-                                                "values": ["admission-webhook"],
-                                            },
-                                            {
-                                                "key": "juju-operator",
-                                                "operator": "NotIn",
-                                                "values": ["admission-webhook"],
-                                            },
-                                            {
-                                                "key": "operator.juju.is/name",
-                                                "operator": "NotIn",
-                                                "values": ["admission-webhook"],
-                                            },
-                                        ]
+                                    "namespaceSelector": {
+                                        "matchLabels": {
+                                            "app.kubernetes.io/part-of": "kubeflow-profile",
+                                        },
                                     },
                                     "rules": [
                                         {

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -24,4 +24,12 @@ async def test_build_and_deploy(ops_test: OpsTest):
         entity_url=built_charm_path,
         resources=resources,
     )
-    await ops_test.model.wait_for_idle(timeout=60 * 60)
+
+async def test_is_active(ops_test: OpsTest):
+    await ops_test.model.wait_for_idle(
+        apps=["admission-webhook"],
+        status="active",
+        raise_on_blocked=True,
+        raise_on_error=True,
+        timeout=300,
+    )

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -25,6 +25,7 @@ async def test_build_and_deploy(ops_test: OpsTest):
         resources=resources,
     )
 
+
 async def test_is_active(ops_test: OpsTest):
     await ops_test.model.wait_for_idle(
         apps=["admission-webhook"],


### PR DESCRIPTION
See #15 for more detail

This PR changes the scope of the mutatingwebhook created by admission-webhook:
* pods created in a kubeflow user namespace (eg: a namespace labeled by the kubeflow profiles conventions) will be subject to this webhook
* all other pods (those in namespace=kubeflow or completely external to kubeflow) will not be touched by this webhook

This has the beneficial side effect that, if the admission-webhook workload is broken, it **will not** block all pods in the entire kubernetes cluster from creating, as has been reported in the past.  It will however still block all kubeflow user pods in user namespaces

This change was manually tested using the procedure described in #15.  Automated tests will be added later as a separate task