### PR TITLE
Observe leader-elected event

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 *.charm
 build/
+.tox/
+__pycache__
+.idea

--- a/src/charm.py
+++ b/src/charm.py
@@ -121,9 +121,9 @@ class CheckFailed(Exception):
     def __init__(self, msg, status_type=None):
         super().__init__()
 
-        self.msg = msg
+        self.msg = str(msg)
         self.status_type = status_type
-        self.status = status_type(msg)
+        self.status = status_type(self.msg)
 
 
 class AdmissionWebhookCharm(CharmBase):
@@ -138,6 +138,7 @@ class AdmissionWebhookCharm(CharmBase):
         self.image = OCIImageResource(self, "oci-image")
         self.framework.observe(self.on.install, self.set_pod_spec)
         self.framework.observe(self.on.upgrade_charm, self.set_pod_spec)
+        self.framework.observe(self.on.leader_elected, self.set_pod_spec)
         self.framework.observe(
             self.on.pod_defaults_relation_changed,
             self.set_pod_spec,

--- a/tox.ini
+++ b/tox.ini
@@ -29,4 +29,3 @@ deps =
 commands =
     flake8 {toxinidir}/src {toxinidir}/tests
     black --check {toxinidir}/src {toxinidir}/tests
-


### PR DESCRIPTION
When we use `juju upgrade-charm`, a new non-leader unit gets created, then the old still-leader one gets removed, resulting in the new unit being elected as the leader.
When the `leader_elected` event is not observed, the charm is not aware of having a leader now, so it remains stuck with message 'Waiting for leadership'.
This PR adds a fix to observe this event.

Note that this charm doesn't have unit tests, I added that to issues.