### PR TITLE
chore: oci image version bump 1.6.0-rc.2 -> 1.6.0

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -11,7 +11,7 @@ resources:
     type: oci-image
     description: Backing OCI image
     auto-fetch: true
-    upstream-source: 'docker.io/kubeflownotebookswg/poddefaults-webhook:v1.6.0-rc.2'
+    upstream-source: 'docker.io/kubeflownotebookswg/poddefaults-webhook:v1.6.0'
 provides:
   pod-defaults:
     interface: pod-defaults


### PR DESCRIPTION
Version bump to 1.6.0 release image

NOTE: this PR depends on the latest image tag specified in [kubeflow/manifests](https://github.com/kubeflow/manifests/blob/v1.6-branch/apps/admission-webhook/upstream/base/kustomization.yaml#L18)