### PR TITLE
fix: pip-compile fileMatch pattern in renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,10 +8,12 @@
     },
     "pip-compile": {
         "fileMatch": [
-            "requirements.in",
-            "requirements-fmt.in",
-            "requirements-lint.in",
-            "requirements-integration.in"
+            "(^|/)requirements\\.in$",
+            "(^|/)requirements-fmt\\.in$",
+            "(^|/)requirements-lint\\.in$",
+            "(^|/)requirements-unit\\.in$",
+            "(^|/)requirements-integration\\.in$",
+            "(^|/)requirements.*\\.in$"
         ],
         "lockFileMaintenance": {
             "enabled": true,


### PR DESCRIPTION
Fixes the fileMatch pattern used by the Renovate bot for pip-compile files.  See [this argo-operators PR](https://github.com/canonical/argo-operators/pull/71) for a full description of the fix.