### PR TITLE
feat update status

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -2,6 +2,6 @@
 # See LICENSE file for licensing details.
 options:
   port:
-    type: string
-    default: '4443'
+    type: int
+    default: 4443
     description: Webhook server port

--- a/src/charm.py
+++ b/src/charm.py
@@ -133,6 +133,7 @@ class AdmissionWebhookCharm(CharmBase):
                     "summary": "Pebble service for admission-webhook-operator",
                     "startup": "enabled",
                     "command": self._exec_command,
+                    "on-check-failure": {"admission-webhook-up": "restart"},
                 },
             },
             "checks": {

--- a/src/charm.py
+++ b/src/charm.py
@@ -18,8 +18,8 @@ from lightkube.models.core_v1 import ServicePort
 from ops.charm import CharmBase
 from ops.framework import StoredState
 from ops.main import main
-from ops.model import ActiveStatus, Container, MaintenanceStatus, WaitingStatus
-from ops.pebble import Layer
+from ops.model import ActiveStatus, Container, MaintenanceStatus, WaitingStatus, ModelError
+from ops.pebble import Layer, CheckStatus
 
 from certs import gen_certs
 
@@ -64,6 +64,7 @@ class AdmissionWebhookCharm(CharmBase):
         self.framework.observe(self.on.install, self._on_install)
         self.framework.observe(self.on.upgrade_charm, self._on_upgrade)
         self.framework.observe(self.on.remove, self._on_remove)
+        self.framework.observe(self.on.update_status, self._on_update_status)
 
         # generate certs
         self._gen_certs_if_missing()
@@ -133,6 +134,15 @@ class AdmissionWebhookCharm(CharmBase):
                     "startup": "enabled",
                     "command": self._exec_command,
                 },
+            },
+            "checks": {
+                "admission-webhook-up": {
+                    "override": "replace",
+                    "period": "30s",
+                    "timeout": "20s",
+                    "threshold": 4,
+                    "tcp": {"port": self._port},
+                }
             },
         }
         return Layer(layer_config)
@@ -238,6 +248,25 @@ class AdmissionWebhookCharm(CharmBase):
             self.logger.warning("Connection cannot be established with container")
             raise ErrorWithStatus("Pod startup is not complete", MaintenanceStatus)
 
+    def _get_check_status(self):
+        return self.container.get_check("admission-webhook-up").status
+
+    def _refresh_status(self):
+        """Check status of workload and set status accordingly."""
+        try:
+            check = self._get_check_status()
+        except ModelError as error:
+            raise GenericCharmRuntimeError(
+                "Failed to run health check on workload container"
+            ) from error
+        if check != CheckStatus.UP:
+            self.logger.error(
+                f"Container {self._container_name} failed health check. It will be restarted."
+            )
+            raise ErrorWithStatus("Workload failed health check", MaintenanceStatus)
+        else:
+            self.model.unit.status = ActiveStatus()
+
     def _on_install(self, _):
         """Installation only tasks."""
         # deploy K8S resources to speed up deployment
@@ -281,6 +310,16 @@ class AdmissionWebhookCharm(CharmBase):
         """Perform upgrade steps."""
         # force conflict resolution in K8S resources update
         self._on_event(_, force_conflicts=True)
+
+    def _on_update_status(self, event):
+        """Update status actions."""
+        self._on_event(event)
+
+        try:
+            self._refresh_status()
+        except ErrorWithStatus as err:
+            self.model.unit.status = err.status
+            self.logger.error(f"Failed to handle {event} with error: {err}")
 
     def _on_event(self, event, force_conflicts: bool = False) -> None:
         """Perform all required actions for the Charm.

--- a/src/charm.py
+++ b/src/charm.py
@@ -18,8 +18,8 @@ from lightkube.models.core_v1 import ServicePort
 from ops.charm import CharmBase
 from ops.framework import StoredState
 from ops.main import main
-from ops.model import ActiveStatus, Container, MaintenanceStatus, WaitingStatus, ModelError
-from ops.pebble import Layer, CheckStatus
+from ops.model import ActiveStatus, Container, MaintenanceStatus, ModelError, WaitingStatus
+from ops.pebble import CheckStatus, Layer
 
 from certs import gen_certs
 

--- a/tests/unit/test_operator.py
+++ b/tests/unit/test_operator.py
@@ -4,8 +4,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from ops.model import ActiveStatus, MaintenanceStatus, WaitingStatus
-from ops.testing import Harness
 from ops.pebble import CheckStatus
+from ops.testing import Harness
 
 from charm import AdmissionWebhookCharm
 
@@ -100,6 +100,8 @@ class TestCharm:
 
     @patch("charm.KubernetesServicePatch", lambda x, y, service_name: None)
     @patch("charm.AdmissionWebhookCharm._get_check_status")
+    @patch("charm.AdmissionWebhookCharm.k8s_resource_handler")
+    @patch("charm.AdmissionWebhookCharm.crd_resource_handler")
     @pytest.mark.parametrize(
         "health_check_status, charm_status",
         [
@@ -109,6 +111,8 @@ class TestCharm:
     )
     def test_update_status(
         self,
+        crd_resource_handler: MagicMock,
+        k8s_resource_handler: MagicMock,
         _get_check_status: MagicMock,
         health_check_status,
         charm_status,

--- a/tests/unit/test_operator.py
+++ b/tests/unit/test_operator.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from ops.model import ActiveStatus, MaintenanceStatus, WaitingStatus
 from ops.testing import Harness
+from ops.pebble import CheckStatus
 
 from charm import AdmissionWebhookCharm
 
@@ -96,6 +97,36 @@ class TestCharm:
         crd_resource_handler.apply.assert_called()
         k8s_resource_handler.apply.assert_called()
         assert isinstance(harness.charm.model.unit.status, MaintenanceStatus)
+
+    @patch("charm.KubernetesServicePatch", lambda x, y, service_name: None)
+    @patch("charm.AdmissionWebhookCharm._get_check_status")
+    @pytest.mark.parametrize(
+        "health_check_status, charm_status",
+        [
+            (CheckStatus.UP, ActiveStatus("")),
+            (CheckStatus.DOWN, MaintenanceStatus("Workload failed health check")),
+        ],
+    )
+    def test_update_status(
+        self,
+        _get_check_status: MagicMock,
+        health_check_status,
+        charm_status,
+        harness: Harness,
+    ):
+        """
+        Test update status handler.
+        Check on the correct charm status when health check status is UP/DOWN.
+        """
+        harness.set_leader(True)
+        harness.begin_with_initial_hooks()
+        harness.container_pebble_ready("admission-webhook")
+
+        _get_check_status.return_value = health_check_status
+
+        # test successful update status
+        harness.charm.on.update_status.emit()
+        assert harness.charm.model.unit.status == charm_status
 
     @patch("charm.KubernetesServicePatch", lambda x, y, service_name: None)
     @pytest.mark.parametrize(


### PR DESCRIPTION
#69 
Summary of changes:
- Added pebble health check on admission-webhook service port. Check is of type `tcp` to check that the admission webhook service port is open. Admission webhook workload does not own a livenessProbe that we can point the Pebble check to, that would be the usual case in other charms.
- Added update-status event handler to report pebble health check status and set the charm status accordingly.
- Added unit test for update-status event handling.