### PR TITLE
fix: revert name change of webhook config

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -244,7 +244,7 @@ class AdmissionWebhookCharm(CharmBase):
                     "customResources": custom_resources,
                     "mutatingWebhookConfigurations": [
                         {
-                            "name": "admission-webhook-mutating-webhook-configuration",
+                            "name": "admission-webhook",
                             "webhooks": [
                                 {
                                     # Probably not necessary, but keeps us in sync with upstream


### PR DESCRIPTION
Fixes #88 