### PR TITLE
fix: rename `mutatingWebhookConfiguration`

### DIFF
--- a/src/templates/webhook_configuration.yaml.j2
+++ b/src/templates/webhook_configuration.yaml.j2
@@ -1,7 +1,7 @@
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
-  name: {{ app_name }}-mutating-webhook-configuration
+  name: {{ app_name }}
 webhooks:
 - admissionReviewVersions:
     - v1beta1


### PR DESCRIPTION
fixes #88 in `main`
corresponding to fix merged in 1.7 #89