### PR TITLE
feat: update version to 1.8.0-rc.0

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -53,13 +53,13 @@ jobs:
       uses: charmed-kubernetes/actions-operator@main
       with:
         provider: microk8s
-        channel: 1.24/stable
+        channel: 1.25-strict/stable
         charmcraft-channel: latest/candidate
-        juju-channel: 2.9/stable
+        juju-channel: 3.1/stable
 
     - name: Test
       run: |
-        sg microk8s -c "tox -vve integration -- --model testing"
+        sg snap_microk8s -c "tox -vve integration -- --model testing"
 
     # On failure, capture debugging resources
     - name: Get all

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -16,7 +16,7 @@ resources:
     type: oci-image
     description: Backing OCI image
     auto-fetch: true
-    upstream-source: docker.io/kubeflownotebookswg/poddefaults-webhook:v1.7.0
+    upstream-source: docker.io/kubeflownotebookswg/poddefaults-webhook:v1.8.0-rc.0
 provides:
   pod-defaults:
     interface: pod-defaults

--- a/requirements-integration.in
+++ b/requirements-integration.in
@@ -1,6 +1,6 @@
 charmed-kubeflow-chisme
-# Pinning to <3.0 to ensure compatibility with the 2.9 controller version
-juju<3.0
+# Pinning to <4.0 due to compatibility with the 3.1 controller version
+juju<4.0
 lightkube
 pytest-operator
 pyyaml

--- a/requirements-integration.txt
+++ b/requirements-integration.txt
@@ -4,9 +4,9 @@
 #
 #    pip-compile requirements-integration.in
 #
-anyio==3.7.1
+anyio==4.0.0
     # via httpcore
-asttokens==2.2.1
+asttokens==2.4.0
     # via stack-data
 attrs==23.1.0
     # via jsonschema
@@ -38,7 +38,7 @@ decorator==5.1.1
     #   ipython
 deepdiff==6.2.1
     # via charmed-kubeflow-chisme
-exceptiongroup==1.1.2
+exceptiongroup==1.1.3
     # via
     #   anyio
     #   pytest
@@ -52,6 +52,8 @@ httpcore==0.17.3
     # via httpx
 httpx==0.24.1
     # via lightkube
+hvac==1.2.0
+    # via juju
 idna==3.4
     # via
     #   anyio
@@ -73,24 +75,20 @@ jinja2==3.1.2
     #   pytest-operator
 jsonschema==4.17.3
     # via serialized-data-interface
-juju==2.9.44.0
+juju==3.2.2
     # via
     #   -r requirements-integration.in
     #   pytest-operator
-jujubundlelib==0.5.7
-    # via theblues
 kubernetes==27.2.0
     # via juju
 lightkube==0.14.0
     # via
     #   -r requirements-integration.in
     #   charmed-kubeflow-chisme
-lightkube-models==1.27.1.4
+lightkube-models==1.28.1.4
     # via lightkube
 macaroonbakery==1.3.1
-    # via
-    #   juju
-    #   theblues
+    # via juju
 markupsafe==2.1.3
     # via jinja2
 matplotlib-inline==0.1.6
@@ -101,7 +99,7 @@ oauthlib==3.2.2
     # via
     #   kubernetes
     #   requests-oauthlib
-ops==2.5.0
+ops==2.6.0
     # via
     #   charmed-kubeflow-chisme
     #   serialized-data-interface
@@ -119,7 +117,7 @@ pickleshare==0.7.5
     # via ipython
 pkgutil-resolve-name==1.3.10
     # via jsonschema
-pluggy==1.2.0
+pluggy==1.3.0
     # via pytest
 prompt-toolkit==3.0.39
     # via ipython
@@ -140,6 +138,8 @@ pycparser==2.21
     # via cffi
 pygments==2.16.1
     # via ipython
+pyhcl==0.4.5
+    # via hvac
 pymacaroons==0.13.0
     # via macaroonbakery
 pynacl==1.5.0
@@ -153,23 +153,22 @@ pyrfc3339==1.1
     #   macaroonbakery
 pyrsistent==0.19.3
     # via jsonschema
-pytest==7.4.0
+pytest==7.4.2
     # via
     #   pytest-asyncio
     #   pytest-operator
 pytest-asyncio==0.21.1
     # via pytest-operator
-pytest-operator==0.28.0
+pytest-operator==0.29.0
     # via -r requirements-integration.in
 python-dateutil==2.8.2
     # via kubernetes
-pytz==2023.3
+pytz==2023.3.post1
     # via pyrfc3339
 pyyaml==6.0.1
     # via
     #   -r requirements-integration.in
     #   juju
-    #   jujubundlelib
     #   kubernetes
     #   lightkube
     #   ops
@@ -177,11 +176,11 @@ pyyaml==6.0.1
     #   serialized-data-interface
 requests==2.31.0
     # via
+    #   hvac
     #   kubernetes
     #   macaroonbakery
     #   requests-oauthlib
     #   serialized-data-interface
-    #   theblues
 requests-oauthlib==1.3.1
     # via kubernetes
 rsa==4.9
@@ -208,12 +207,10 @@ sniffio==1.3.0
     #   httpx
 stack-data==0.6.2
     # via ipython
-tenacity==8.2.2
+tenacity==8.2.3
     # via
     #   -r requirements-integration.in
     #   charmed-kubeflow-chisme
-theblues==0.5.2
-    # via juju
 tomli==2.0.1
     # via
     #   ipdb
@@ -237,11 +234,11 @@ urllib3==1.26.16
     #   requests
 wcwidth==0.2.6
     # via prompt-toolkit
-websocket-client==1.6.1
+websocket-client==1.6.2
     # via
     #   kubernetes
     #   ops
-websockets==7.0
+websockets==8.1
     # via juju
 zipp==3.16.2
     # via importlib-resources


### PR DESCRIPTION
Bump image version to `v1.8.0-rc.0` in preparation for the 1.8 release based on kubeflow/manifests repo tag `v1.8.0-rc.0`.

No changes were observed for the manifests and CRDs.