### PR TITLE
feat: update version to 1.8.0-rc.0

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -16,7 +16,7 @@ resources:
     type: oci-image
     description: Backing OCI image
     auto-fetch: true
-    upstream-source: docker.io/kubeflownotebookswg/poddefaults-webhook:v1.7.0
+    upstream-source: docker.io/kubeflownotebookswg/poddefaults-webhook:v1.8.0-rc.0
 provides:
   pod-defaults:
     interface: pod-defaults


### PR DESCRIPTION
Bump image version to `v1.8.0-rc.0` in preparation for the 1.8 release based on kubeflow/manifests repo tag `v1.8.0-rc.0`.

No changes were observed for the manifests and CRDs.