### PR TITLE
fix: defer pebble ready event if container is not ready

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -227,12 +227,13 @@ class AdmissionWebhookCharm(CharmBase):
         for k, v in certs.items():
             setattr(self._stored, k, v)
 
-    def _upload_certs_to_container(self):
+    def _upload_certs_to_container(self, event):
         """Upload generated certs to container."""
         try:
             self._check_container_connection(self.container)
         except ErrorWithStatus as error:
             self.model.unit.status = error.status
+            event.defer()
             return
 
         self.container.push(CONTAINER_CERTS_DEST / "key.pem", self._cert_key, make_dirs=True)
@@ -303,7 +304,7 @@ class AdmissionWebhookCharm(CharmBase):
     def _on_pebble_ready(self, event):
         """Configure started container."""
         # upload certs to container
-        self._upload_certs_to_container()
+        self._upload_certs_to_container(event)
 
         # proceed with other actions
         self._on_event(event)


### PR DESCRIPTION
Deferring the pebble ready event will ensure that the required operations that need to happen before starting the service are in place. In this case, certificate files need to be present in the container, but sometimes the container is not reachable, causing the action of pushing these files to the container impossible. In the past we returned if the container was not reachable, but never tried to reach out to it and push the files, this commit ensures the retry via defer. Fixes 110