### PR TITLE
Update admission-webhook to 2.2.0

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -16,7 +16,7 @@ resources:
     type: oci-image
     description: Backing OCI image
     auto-fetch: true
-    upstream-source: docker.io/kubeflownotebookswg/poddefaults-webhook:v1.8.0
+    upstream-source: docker.io/kubeflownotebookswg/poddefaults-webhook:v1.9.0-rc.0
 provides:
   pod-defaults:
     interface: pod-defaults


### PR DESCRIPTION
Closes: https://github.com/canonical/admission-webhook-operator/issues/131

I have compared tags `v1.8.0` and `v1.9.0-rc.0` for this files https://github.com/kubeflow/kubeflow/tree/master/components/admission-webhook/manifests/overlays/cert-manager

Only change was the image tag.