### PR TITLE
ci: use juju 3.4/stable instead of 3.5/stable

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -55,7 +55,7 @@ jobs:
         provider: microk8s
         channel: 1.29-strict/stable
         charmcraft-channel: latest/candidate
-        juju-channel: 3.5/stable
+        juju-channel: 3.4/stable
 
     - name: Test
       run: |


### PR DESCRIPTION
Part of canonical/bundle-kubeflow#944