### PR TITLE
chore: update manifests for kf v1.9.0

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -16,7 +16,7 @@ resources:
     type: oci-image
     description: Backing OCI image
     auto-fetch: true
-    upstream-source: docker.io/kubeflownotebookswg/poddefaults-webhook:v1.9.0-rc.0
+    upstream-source: docker.io/kubeflownotebookswg/poddefaults-webhook
 provides:
   pod-defaults:
     interface: pod-defaults

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -16,7 +16,7 @@ resources:
     type: oci-image
     description: Backing OCI image
     auto-fetch: true
-    upstream-source: docker.io/kubeflownotebookswg/poddefaults-webhook
+    upstream-source: docker.io/kubeflownotebookswg/poddefaults-webhook:v1.9.0
 provides:
   pod-defaults:
     interface: pod-defaults


### PR DESCRIPTION
Closes: https://github.com/canonical/admission-webhook-operator/issues/143

I have compared tags `v1.9.0` and `v1.9.0-rc.0` for this files https://github.com/kubeflow/kubeflow/tree/master/components/admission-webhook/manifests/overlays/cert-manager.

I have also compared from manifest repository
https://github.com/kubeflow/manifests/tree/v1.9.0

Only change was the image tag.