### PR TITLE
Backport: Integrate rock

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -16,7 +16,7 @@ resources:
     type: oci-image
     description: Backing OCI image
     auto-fetch: true
-    upstream-source: docker.io/kubeflownotebookswg/poddefaults-webhook:v1.9.0
+    upstream-source: charmedkubeflow/admission-webhook:v1.9.0-b041e5f
 provides:
   pod-defaults:
     interface: pod-defaults


### PR DESCRIPTION
This PR is a backport of #151.

It integrates the PodDefaults rock into admission-webhook for the CKF 1.9 bundle.

