### PR TITLE
feat: integrate admission-webhook rock for `1.10.0`

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -16,7 +16,7 @@ resources:
     type: oci-image
     description: Backing OCI image
     auto-fetch: true
-    upstream-source: charmedkubeflow/admission-webhook:v1.9.0-b041e5f
+    upstream-source: charmedkubeflow/admission-webhook:1.10.0-rc.0-d5781e6
 provides:
   pod-defaults:
     interface: pod-defaults


### PR DESCRIPTION
Integrate new rock for admission webhook https://hub.docker.com/layers/charmedkubeflow/admission-webhook/1.10.0-rc.0-d5781e6/images/sha256-bf787a02549c87ab1d1ba55b432a818889e7cb670534cbe80b4a0e0c9bac12ec