### PR TITLE
chore: bump admission-webhook to `v1.10.0-rc.1`

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -16,7 +16,7 @@ resources:
     type: oci-image
     description: Backing OCI image
     auto-fetch: true
-    upstream-source: charmedkubeflow/admission-webhook:v1.9.0-b041e5f
+    upstream-source: docker.io/kubeflownotebookswg/poddefaults-webhook:v1.10.0-rc.1
 provides:
   pod-defaults:
     interface: pod-defaults


### PR DESCRIPTION
Closes https://warthogs.atlassian.net/browse/KF-6859

Updates the admission-webhook image to `v1.10.0-rc.1`.
There were no changes in manifests, see https://github.com/kubeflow/manifests/tree/v1.10.0-rc.1/apps/admission-webhook/upstream.