### PR TITLE
chore: bump admission-webhook to v1.10.0-rc.2

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -16,7 +16,7 @@ resources:
     type: oci-image
     description: Backing OCI image
     auto-fetch: true
-    upstream-source: docker.io/kubeflownotebookswg/poddefaults-webhook:v1.10.0-rc.1
+    upstream-source: charmedkubeflow/admission-webhook:1.10.0-rc.1-273516f
 provides:
   pod-defaults:
     interface: pod-defaults


### PR DESCRIPTION
Closes https://warthogs.atlassian.net/browse/KF-7045

There were no changes in manifests for rc.2 [see here](https://github.com/kubeflow/manifests/tree/master/apps/admission-webhook/upstream/base), only the image version was updated. so this PR just integrates the rock for rc.2 (i.e. image version rc.1).