### PR TITLE
chore(ci): Update CI to use 24.04

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -29,8 +29,7 @@ jobs:
         python-version: 3.8
         
     - name: Install dependencies
-      run: |
-        pip install tox
+      run: pip install tox
     - name: Lint code
       run: tox -vve lint
 
@@ -42,6 +41,11 @@ jobs:
     - name: Check out code
       uses: actions/checkout@v4
 
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v5.3.0
+      with:
+        python-version: 3.8
+      
     - name: Install dependencies
       run: pip install tox
 

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -17,28 +17,33 @@ jobs:
 
   lint:
     name: Lint
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
     - name: Check out code
       uses: actions/checkout@v4
+      
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v5.3.0
+      with:
+        python-version: 3.8
+        
     - name: Install dependencies
       run: |
-        sudo apt update
-        sudo apt install tox
+        pip install tox
     - name: Lint code
       run: tox -vve lint
 
   unit:
     name: Unit Test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
     - name: Check out code
       uses: actions/checkout@v4
 
     - name: Install dependencies
-      run: sudo apt-get install python3-pip tox
+      run: pip install tox
 
     - name: Run unit tests
       run: tox -e unit
@@ -51,10 +56,16 @@ jobs:
 
   integration:
     name: Integration Tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - name: Check out code
       uses: actions/checkout@v4
+
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v5.3.0
+      with:
+        python-version: 3.8
+        
     - name: Setup operator environment
       uses: charmed-kubernetes/actions-operator@main
       with:
@@ -65,7 +76,7 @@ jobs:
 
     - name: Test
       run: |
-        sg snap_microk8s -c "tox -vve integration -- --model testing"
+        tox -vve integration -- --model testing
 
     # On failure, capture debugging resources
     - name: Get all

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -5,7 +5,7 @@ on:
   workflow_call:
     inputs:
       source_branch:
-        description: Github branch from this repo to publish.  If blank, will use the default branch
+        description: Github branch from this repo to publish. If blank, will use the default branch
         default: ''
         required: false
         type: string
@@ -20,7 +20,7 @@ on:
         default: 'latest/edge'
         type: string
       source_branch:
-        description: Github branch from this repo to publish.  If blank, will use the default branch
+        description: Github branch from this repo to publish. If blank, will use the default branch
         required: false
         default: ''
         type: string
@@ -28,7 +28,7 @@ on:
 jobs:
   get-charm-paths:
     name: Generate the Charm Matrix
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     outputs:
       charm_paths_list: ${{ steps.get-charm-paths.outputs.CHARM_PATHS_LIST }}
     steps:
@@ -43,7 +43,7 @@ jobs:
 
   publish-charm:
     name: Publish Charm
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     needs: get-charm-paths
     strategy:
       fail-fast: false
@@ -83,6 +83,12 @@ jobs:
           echo "setting output of tag_prefix=$tag_prefix"
           echo "::set-output name=tag_prefix::$tag_prefix"
 
+        # Required to charmcraft pack in non-destructive mode
+      - name: Setup lxd
+        uses: canonical/setup-lxd@v0.1.2
+        with:
+          channel: latest/stable
+          
       - name: Upload charm to charmhub
         uses: canonical/charming-actions/upload-charm@2.6.2
         with:
@@ -92,3 +98,4 @@ jobs:
           channel: ${{ steps.parse-inputs.outputs.destination_channel }}
           tag-prefix: ${{ steps.parse-inputs.outputs.tag_prefix }}
           charmcraft-channel: 3.x/stable
+          destructive-mode: false

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,7 +14,7 @@ on:
 jobs:
   promote-charm:
     name: Promote charm
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: Release charm to channel


### PR DESCRIPTION
Closes #172 

This PR updates the CI to use 24.04:

   - We also use `setup-python` to use Python version 3.8.
   - We set `destructive-mode` to false since we're now building on a different base than the one we are on.
   - We don't need to use `sg` to switch the group when running `tox -e integration` 