### PR TITLE
chore: Update rock to 1.10 version

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -16,7 +16,7 @@ resources:
     type: oci-image
     description: Backing OCI image
     auto-fetch: true
-    upstream-source: charmedkubeflow/admission-webhook:1.10.0-rc.1-273516f
+    upstream-source: charmedkubeflow/admission-webhook:1.10.0-8dd1032
 provides:
   pod-defaults:
     interface: pod-defaults


### PR DESCRIPTION
This PR updates the `upstream-source` image to use the latest version of `admission-webhook`

To view if there were any miscellaneous manifest changes, I compared the 2 tags: https://github.com/kubeflow/manifests/compare/v1.10.0-rc.2...v1.10.0-rc.3