### PR TITLE
chore: Update chisme in requirements

### DIFF
--- a/requirements-integration.in
+++ b/requirements-integration.in
@@ -1,4 +1,6 @@
-charmed-kubeflow-chisme
+# "charmed-kubeflow-chisme" pinned to avoid closed "latest" tracks with COS charms, see:
+# https://github.com/canonical/charmed-kubeflow-chisme/issues/155
+charmed-kubeflow-chisme>=0.4.11
 # Pinning to <4.0 due to compatibility with the 3.1 controller version
 juju<4.0
 lightkube

--- a/requirements-integration.txt
+++ b/requirements-integration.txt
@@ -26,7 +26,7 @@ cffi==1.17.1
     # via
     #   cryptography
     #   pynacl
-charmed-kubeflow-chisme==0.4.3
+charmed-kubeflow-chisme==0.4.11
     # via -r requirements-integration.in
 charset-normalizer==3.4.0
     # via requests
@@ -47,7 +47,9 @@ h11==0.14.0
 httpcore==1.0.7
     # via httpx
 httpx==0.27.2
-    # via lightkube
+    # via
+    #   charmed-kubeflow-chisme
+    #   lightkube
 hvac==2.3.0
     # via juju
 idna==3.10

--- a/requirements-unit.txt
+++ b/requirements-unit.txt
@@ -24,7 +24,7 @@ cffi==1.17.1
     # via
     #   cryptography
     #   pynacl
-charmed-kubeflow-chisme==0.4.3
+charmed-kubeflow-chisme==0.4.11
     # via -r requirements.in
 charset-normalizer==3.4.0
     # via requests
@@ -43,7 +43,9 @@ h11==0.14.0
 httpcore==1.0.7
     # via httpx
 httpx==0.27.2
-    # via lightkube
+    # via
+    #   charmed-kubeflow-chisme
+    #   lightkube
 hvac==2.3.0
     # via juju
 idna==3.10

--- a/requirements.in
+++ b/requirements.in
@@ -1,6 +1,8 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
-charmed-kubeflow-chisme
+# "charmed-kubeflow-chisme" pinned to avoid closed "latest" tracks with COS charms, see:
+# https://github.com/canonical/charmed-kubeflow-chisme/issues/155
+charmed-kubeflow-chisme>=0.4.11
 lightkube
 ops
 pyyaml

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ cffi==1.17.1
     # via
     #   cryptography
     #   pynacl
-charmed-kubeflow-chisme==0.4.3
+charmed-kubeflow-chisme==0.4.11
     # via -r requirements.in
 charset-normalizer==3.4.0
     # via requests
@@ -41,7 +41,9 @@ h11==0.14.0
 httpcore==1.0.7
     # via httpx
 httpx==0.27.2
-    # via lightkube
+    # via
+    #   charmed-kubeflow-chisme
+    #   lightkube
 hvac==2.3.0
     # via juju
 idna==3.10


### PR DESCRIPTION
This PR updates `charmed_kubeflow_chisme` to fix https://github.com/canonical/charmed-kubeflow-chisme/issues/155