### PR TITLE
Update `integrate` action to use Canonical k8s installed via `concierge`

### DIFF
--- a/.github/concierge.yaml
+++ b/.github/concierge.yaml
@@ -1,0 +1,13 @@
+juju:
+  channel: 3.6/stable
+
+providers:
+  k8s:
+    enable: true
+    bootstrap: true
+    channel: 1.32-classic/stable
+
+host:
+  snaps:
+    charmcraft:
+      channel: 3.x/stable

--- a/.github/concierge.yaml
+++ b/.github/concierge.yaml
@@ -1,5 +1,5 @@
 juju:
-  channel: 3.6/stable
+  channel: 3.5/stable
 
 providers:
   k8s:

--- a/.github/concierge.yaml
+++ b/.github/concierge.yaml
@@ -8,6 +8,8 @@ providers:
     channel: 1.32-classic/stable
     features:
       local-storage:
+    bootstrap-constraints:
+      root-disk: 2G
 
   lxd:
     enable: true

--- a/.github/concierge.yaml
+++ b/.github/concierge.yaml
@@ -7,6 +7,10 @@ providers:
     bootstrap: true
     channel: 1.32-classic/stable
 
+  lxd:
+    enable: true
+    bootstrap: false
+
 host:
   snaps:
     charmcraft:

--- a/.github/concierge.yaml
+++ b/.github/concierge.yaml
@@ -1,11 +1,13 @@
 juju:
-  channel: 3.5/stable
+  channel: 3.6/stable
 
 providers:
   k8s:
     enable: true
     bootstrap: true
     channel: 1.32-classic/stable
+    features:
+      local-storage:
 
   lxd:
     enable: true

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -58,7 +58,7 @@ jobs:
     - name: Setup operator environment
       run: |
         snap install concierge --classic
-        concierge prepare -p k8s
+        sudo concierge prepare -p k8s
     # - name: Setup operator environment
     #   uses: charmed-kubernetes/actions-operator@main
     #   with:

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -56,12 +56,15 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Setup operator environment
-      uses: charmed-kubernetes/actions-operator@main
-      with:
-        provider: microk8s
-        channel: 1.32-strict/stable
-        charmcraft-channel: 3.x/stable
-        juju-channel: 3.6/stable
+      run: |
+        concierge prepare -p k8s
+    # - name: Setup operator environment
+    #   uses: charmed-kubernetes/actions-operator@main
+    #   with:
+    #     provider: microk8s
+    #     channel: 1.32-strict/stable
+    #     charmcraft-channel: 3.x/stable
+    #     juju-channel: 3.6/stable
 
     - name: Test
       run: |

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -57,6 +57,7 @@ jobs:
 
     - name: Setup operator environment
       run: |
+        pipx install tox
         sudo apt-get remove -y docker-ce docker-ce-cli containerd.io
         sudo rm -rf /run/containerd
         sudo snap install concierge --classic

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -59,15 +59,11 @@ jobs:
       run: pipx install tox
       
     - name: Setup operator environment
-      env:
-        CONCIERGE_CHARMCRAFT_CHANNEL: "3.x/stable"
-        CONCIERGE_JUJU_CHANNEL: "3.6/stable"
-        CONCIERGE_K8S_CHANNEL: "1.32-strict/stable"
       run: |
         sudo apt-get remove -y docker-ce docker-ce-cli containerd.io
         sudo rm -rf /run/containerd
         sudo snap install concierge --classic
-        sudo concierge prepare -p k8s
+        sudo concierge prepare -c .github/concierge.yaml --trace
 
     - name: Test
       run: |

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -57,7 +57,7 @@ jobs:
 
     - name: Setup operator environment
       run: |
-        snap install concierge --classic
+        sudo snap install concierge --classic
         sudo concierge prepare -p k8s
     # - name: Setup operator environment
     #   uses: charmed-kubernetes/actions-operator@main

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -64,7 +64,6 @@ jobs:
         sudo rm -rf /run/containerd
         sudo snap install concierge --classic
         sudo concierge prepare -c .github/concierge.yaml --trace
-        ls
 
     - name: Test
       run: |

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -64,10 +64,10 @@ jobs:
         CONCIERGE_JUJU_CHANNEL: "3.6/stable"
         CONCIERGE_K8S_CHANNEL: "1.32-strict/stable"
       run: |
-        apt-get remove -y docker-ce docker-ce-cli containerd.io
-        rm -rf /run/containerd
-        snap install concierge --classic
-        concierge prepare -p k8s
+        sudo apt-get remove -y docker-ce docker-ce-cli containerd.io
+        sudo rm -rf /run/containerd
+        sudo snap install concierge --classic
+        sudo concierge prepare -p k8s
 
     - name: Test
       run: |

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -56,6 +56,10 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Setup operator environment
+      env: |
+        CONCIERGE_CHARMCRAFT_CHANNEL: "3.x/stable"
+        CONCIERGE_JUJU_CHANNEL: "3.6/stable"
+        CONCIERGE_K8S_CHANNEL: "1.31-strict/stable"
       run: |
         pipx install tox
         sudo apt-get remove -y docker-ce docker-ce-cli containerd.io

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -64,6 +64,7 @@ jobs:
         sudo rm -rf /run/containerd
         sudo snap install concierge --classic
         sudo concierge prepare -c .github/concierge.yaml --trace
+        ls
 
     - name: Test
       run: |

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -57,6 +57,7 @@ jobs:
 
     - name: Setup operator environment
       run: |
+        snap install concierge --classic
         concierge prepare -p k8s
     # - name: Setup operator environment
     #   uses: charmed-kubernetes/actions-operator@main

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -93,3 +93,8 @@ jobs:
     - name: Get application operator logs
       run: kubectl logs -n testing --tail 1000 -ljuju-operator=admission-webhook
       if: failure()
+
+    - name: Setup tmate session
+      uses: mxschmitt/action-tmate@v3
+      if: failure()
+      timeout-minutes: 40

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -57,6 +57,7 @@ jobs:
 
     - name: Setup operator environment
       run: |
+        sudo apt-get remove -y docker-ce docker-ce-cli containerd.io
         sudo rm -rf /run/containerd
         sudo snap install concierge --classic
         sudo concierge prepare -p k8s

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -57,6 +57,7 @@ jobs:
 
     - name: Setup operator environment
       run: |
+        sudo rm -rf /run/containerd
         sudo snap install concierge --classic
         sudo concierge prepare -p k8s
     # - name: Setup operator environment

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -55,13 +55,15 @@ jobs:
     - name: Check out code
       uses: actions/checkout@v4
 
+    - name: Install dependencies
+      run: pipx install tox
+      
     - name: Setup operator environment
       env:
         CONCIERGE_CHARMCRAFT_CHANNEL: "3.x/stable"
         CONCIERGE_JUJU_CHANNEL: "3.6/stable"
         CONCIERGE_K8S_CHANNEL: "1.32-strict/stable"
       run: |
-        pipx install tox
         sudo apt-get remove -y docker-ce docker-ce-cli containerd.io
         sudo rm -rf /run/containerd
         sudo snap install concierge --classic

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -58,7 +58,7 @@ jobs:
     - name: Install dependencies
       run: pipx install tox
       
-    - name: Setup operator environment
+    - name: Setup concierge environment
       run: |
         sudo apt-get remove -y docker-ce docker-ce-cli containerd.io
         sudo rm -rf /run/containerd
@@ -93,8 +93,3 @@ jobs:
     - name: Get application operator logs
       run: kubectl logs -n testing --tail 1000 -ljuju-operator=admission-webhook
       if: failure()
-
-    - name: Setup tmate session
-      uses: mxschmitt/action-tmate@v3
-      if: failure()
-      timeout-minutes: 40

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -64,10 +64,10 @@ jobs:
         CONCIERGE_JUJU_CHANNEL: "3.6/stable"
         CONCIERGE_K8S_CHANNEL: "1.32-strict/stable"
       run: |
-        sudo apt-get remove -y docker-ce docker-ce-cli containerd.io
-        sudo rm -rf /run/containerd
-        sudo snap install concierge --classic
-        sudo concierge prepare -p k8s
+        apt-get remove -y docker-ce docker-ce-cli containerd.io
+        rm -rf /run/containerd
+        snap install concierge --classic
+        concierge prepare -p k8s
 
     - name: Test
       run: |

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -56,7 +56,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Setup operator environment
-      env: |
+      env:
         CONCIERGE_CHARMCRAFT_CHANNEL: "3.x/stable"
         CONCIERGE_JUJU_CHANNEL: "3.6/stable"
         CONCIERGE_K8S_CHANNEL: "1.31-strict/stable"

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -63,7 +63,7 @@ jobs:
         sudo apt-get remove -y docker-ce docker-ce-cli containerd.io
         sudo rm -rf /run/containerd
         sudo snap install concierge --classic
-        sudo concierge prepare -c .github/concierge.yaml --trace
+        sudo concierge prepare -c concierge.yaml --trace
 
     - name: Test
       run: |

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -59,20 +59,13 @@ jobs:
       env:
         CONCIERGE_CHARMCRAFT_CHANNEL: "3.x/stable"
         CONCIERGE_JUJU_CHANNEL: "3.6/stable"
-        CONCIERGE_K8S_CHANNEL: "1.31-strict/stable"
+        CONCIERGE_K8S_CHANNEL: "1.32-strict/stable"
       run: |
         pipx install tox
         sudo apt-get remove -y docker-ce docker-ce-cli containerd.io
         sudo rm -rf /run/containerd
         sudo snap install concierge --classic
         sudo concierge prepare -p k8s
-    # - name: Setup operator environment
-    #   uses: charmed-kubernetes/actions-operator@main
-    #   with:
-    #     provider: microk8s
-    #     channel: 1.32-strict/stable
-    #     charmcraft-channel: 3.x/stable
-    #     juju-channel: 3.6/stable
 
     - name: Test
       run: |

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -63,7 +63,7 @@ jobs:
         sudo apt-get remove -y docker-ce docker-ce-cli containerd.io
         sudo rm -rf /run/containerd
         sudo snap install concierge --classic
-        sudo concierge prepare -c concierge.yaml --trace
+        sudo concierge prepare --trace
 
     - name: Test
       run: |

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -58,7 +58,7 @@ jobs:
     - name: Install dependencies
       run: pipx install tox
       
-    - name: Setup concierge environment
+    - name: Setup environment
       run: |
         sudo apt-get remove -y docker-ce docker-ce-cli containerd.io
         sudo rm -rf /run/containerd

--- a/concierge.yaml
+++ b/concierge.yaml
@@ -1,5 +1,7 @@
 juju:
   channel: 3.6/stable
+  model-defaults:
+    logging-config: <root>=INFO; unit=DEBUG
 
 providers:
   k8s:

--- a/concierge.yaml
+++ b/concierge.yaml
@@ -8,6 +8,7 @@ providers:
     channel: 1.32-classic/stable
     features:
       local-storage:
+        enabled: true
     bootstrap-constraints:
       root-disk: 2G
 

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -43,7 +43,7 @@ async def test_build_and_deploy(ops_test: OpsTest):
 
     # Deploying grafana-agent-k8s and add all relations
     await deploy_and_assert_grafana_agent(
-        ops_test.model, APP_NAME, metrics=False, dashboard=False, logging=True
+        ops_test.model, APP_NAME, metrics=False, dashboard=False, logging=True, 
     )
 
 

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -43,7 +43,11 @@ async def test_build_and_deploy(ops_test: OpsTest):
 
     # Deploying grafana-agent-k8s and add all relations
     await deploy_and_assert_grafana_agent(
-        ops_test.model, APP_NAME, metrics=False, dashboard=False, logging=True, 
+        ops_test.model,
+        APP_NAME,
+        metrics=False,
+        dashboard=False,
+        logging=True,
     )
 
 


### PR DESCRIPTION
Closes https://github.com/canonical/bundle-kubeflow/issues/1326

This PR changes the `Setup Operator Enrivonment` job of the `integrate.yaml` action to install Canonical `k8s` using `concierge`. Note that we specify the versions of `juju`, `charmcraft` and `k8s` using environment variables.

There's also a small linting error fixed.

## Notes
- We also install `tox` since we use it to run the integration tests
- We currently cannot change the Juju model's name that is created by `concierge`, as it is [hardcoded](https://github.com/canonical/concierge/blob/1a0871ecaf6746c79a8cfa2a518458ac42fdc734/internal/juju/juju.go#L226)