### PR TITLE
chore: Update CI to use Canonical K8s

### DIFF
--- a/concierge.yaml
+++ b/concierge.yaml
@@ -1,7 +1,5 @@
 juju:
   channel: 3.6/stable
-  model-defaults:
-    logging-config: <root>=INFO; unit=DEBUG
 
 providers:
   k8s:
@@ -10,9 +8,12 @@ providers:
     channel: 1.32-classic/stable
     features:
       local-storage:
+      load-balancer:
         enabled: true
+        l2-mode: true
+        cidrs: 10.64.140.43/32
     bootstrap-constraints:
-      root-disk: 2G
+      root-disk: 4G
 
   lxd:
     enable: true


### PR DESCRIPTION
Ref: https://github.com/canonical/bundle-kubeflow/issues/1334

This PR:
- Updates the CI to use [Canonical Kubernetes](https://documentation.ubuntu.com/canonical-kubernetes/release-1.32/) instead of microk8s.
- Includes a `concierge.yaml` in the root directory for easily deploying a Canonical K8s cluster using `concierge`.
