### PR TITLE
feat: Add latest/stable channel for LXD

### DIFF
--- a/concierge.yaml
+++ b/concierge.yaml
@@ -17,6 +17,7 @@ providers:
   lxd:
     enable: true
     bootstrap: false
+    channel: latest/stable
 
 host:
   snaps:


### PR DESCRIPTION
This PR adds a channel for `lxd` in `concierge.yaml`. This is in accordance to all of our repositories, to ensure that the version of `lxd` is consistent.