### PR TITLE
(backport): Update CI to use Canonical K8s

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -55,13 +55,15 @@ jobs:
     - name: Check out code
       uses: actions/checkout@v4
 
-    - name: Setup operator environment
-      uses: charmed-kubernetes/actions-operator@main
-      with:
-        provider: microk8s
-        channel: 1.32-strict/stable
-        charmcraft-channel: 3.x/stable
-        juju-channel: 3.6/stable
+    - name: Install dependencies
+      run: pipx install tox
+      
+    - name: Setup environment
+      run: |
+        sudo apt-get remove -y docker-ce docker-ce-cli containerd.io
+        sudo rm -rf /run/containerd
+        sudo snap install concierge --classic
+        sudo concierge prepare --trace
 
     - name: Test
       run: |

--- a/concierge.yaml
+++ b/concierge.yaml
@@ -17,6 +17,7 @@ providers:
   lxd:
     enable: true
     bootstrap: false
+    channel: latest/stable
 
 host:
   snaps:

--- a/concierge.yaml
+++ b/concierge.yaml
@@ -1,0 +1,24 @@
+juju:
+  channel: 3.6/stable
+  model-defaults:
+    logging-config: <root>=INFO; unit=DEBUG
+
+providers:
+  k8s:
+    enable: true
+    bootstrap: true
+    channel: 1.32-classic/stable
+    features:
+      local-storage:
+        enabled: true
+    bootstrap-constraints:
+      root-disk: 2G
+
+  lxd:
+    enable: true
+    bootstrap: false
+
+host:
+  snaps:
+    charmcraft:
+      channel: 3.x/stable

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -43,7 +43,11 @@ async def test_build_and_deploy(ops_test: OpsTest):
 
     # Deploying grafana-agent-k8s and add all relations
     await deploy_and_assert_grafana_agent(
-        ops_test.model, APP_NAME, metrics=False, dashboard=False, logging=True
+        ops_test.model,
+        APP_NAME,
+        metrics=False,
+        dashboard=False,
+        logging=True,
     )
 
 


### PR DESCRIPTION
Ref: https://github.com/canonical/bundle-kubeflow/issues/1334

This PR backports the update to use Canonical K8s in our integration tests. Note that we also backport a fix to use `24.04` as base in the `release-charm` action.