### PR TITLE
chore: Pin charm base to 24.04 in Terraform module and `release-charm` actions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,3 +24,4 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           destination-channel: ${{ github.event.inputs.destination-channel }}
           origin-channel: ${{ github.event.inputs.origin-channel }}
+          base-channel: "24.04"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,6 +1,7 @@
 resource "juju_application" "admission_webhook" {
   charm {
     name     = "admission-webhook"
+        base     = var.base
     channel  = var.channel
     revision = var.revision
   }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -4,6 +4,12 @@ variable "app_name" {
   default     = "admission-webhook"
 }
 
+
+variable "base" {
+  description = "Application base"
+  type        = string
+  default     = "ubuntu@24.04"
+}
 variable "channel" {
   description = "Charm channel"
   type        = string


### PR DESCRIPTION
Ref: https://github.com/canonical/bundle-kubeflow/issues/1347

This PR:
- Updates the default base in the Terraform modules to `24.04`.
- Pins the base in the `release-charm` action to `24.04`, to override the default value of `20.04`
