### PR TITLE
chore: Pin charm base to 24.04 in Terraform module and `release-charm` actions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,3 +24,4 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           destination-channel: ${{ github.event.inputs.destination-channel }}
           origin-channel: ${{ github.event.inputs.origin-channel }}
+          base-channel: "24.04"

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -13,6 +13,7 @@ The module offers the following configurable inputs:
 | Name | Type | Description | Required |
 | - | - | - | - |
 | `app_name`| string | Application name | False |
+| `base`| string | Charm base | False |
 | `channel`| string | Channel that the charm is deployed from | False |
 | `config`| map(string) | Map of the charm configuration options | False |
 | `model_name`| string | Name of the model that the charm is deployed on | True |

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,6 +1,7 @@
 resource "juju_application" "admission_webhook" {
   charm {
     name     = "admission-webhook"
+    base     = var.base
     channel  = var.channel
     revision = var.revision
   }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -4,6 +4,12 @@ variable "app_name" {
   default     = "admission-webhook"
 }
 
+variable "base" {
+  description = "Charm base"
+  type        = string
+  default     = "ubuntu@24.04"
+}
+
 variable "channel" {
   description = "Charm channel"
   type        = string


### PR DESCRIPTION
Ref: https://github.com/canonical/bundle-kubeflow/issues/1347

This PR is a backport of #224.