### PR TITLE
fix: Run `populate-labels` action only when PR is opened/reopened

### DIFF
--- a/.github/workflows/on_pull_request.yaml
+++ b/.github/workflows/on_pull_request.yaml
@@ -12,7 +12,7 @@ jobs:
 
   populate-labels:
     name: Populate labels
-    if: github.base_ref == 'main' && github.event.action = 'opened'
+    if: github.base_ref == 'main' && github.event.action == 'opened'
     uses: canonical/charmed-kubeflow-workflows/.github/workflows/populate-labels.yaml@main
     secrets: inherit
     with:

--- a/.github/workflows/on_pull_request.yaml
+++ b/.github/workflows/on_pull_request.yaml
@@ -1,7 +1,7 @@
 name: On Pull Request
 
 # On pull_request, we:
-# * create backport labels if it is against main
+# * create backport labels if it is against main, only once when the PR is opened
 # * always publish to charmhub at latest/edge/branchname
 # * always run tests
 
@@ -12,7 +12,7 @@ jobs:
 
   populate-labels:
     name: Populate labels
-    if: github.base_ref == 'main'
+    if: github.base_ref == 'main' && github.event.action = 'opened'
     uses: canonical/charmed-kubeflow-workflows/.github/workflows/populate-labels.yaml@main
     secrets: inherit
     with:

--- a/.github/workflows/on_pull_request.yaml
+++ b/.github/workflows/on_pull_request.yaml
@@ -1,7 +1,7 @@
 name: On Pull Request
 
 # On pull_request, we:
-# * create backport labels if it is against main, only once when the PR is opened
+# * create backport labels if it is against main, only when the PR is opened/reopened
 # * always publish to charmhub at latest/edge/branchname
 # * always run tests
 
@@ -12,7 +12,7 @@ jobs:
 
   populate-labels:
     name: Populate labels
-    if: github.base_ref == 'main' && github.event.action == 'opened'
+    if: github.base_ref == 'main' && (github.event.action == 'opened' || github.event.action == 'reopened')
     uses: canonical/charmed-kubeflow-workflows/.github/workflows/populate-labels.yaml@main
     secrets: inherit
     with:

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This charm encompasses the Kubernetes Python operator for Kubeflow's Admission W
 
 ## Install
 
-To  install the Admission Webhook, run:
+To install the Admission Webhook, run:
 
     juju deploy admission-webhook --trust
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This charm encompasses the Kubernetes Python operator for Kubeflow's Admission W
 
 ## Install
 
-To install the Admission Webhook, run:
+To  install the Admission Webhook, run:
 
     juju deploy admission-webhook --trust
 


### PR DESCRIPTION
Closes https://github.com/canonical/charmed-kubeflow-workflows/issues/129

This PR updates `on_pull_request.yaml` to only run the `populate-labels` action when the PR is opened or reopened. This avoids unnecessary running of the action, and the creation of multiple comments.