### PR TITLE
chore: add `track/2.0` to default backport PR action

### DIFF
--- a/.github/automatic_backport_tracks.yaml
+++ b/.github/automatic_backport_tracks.yaml
@@ -1,2 +1,3 @@
 automatic_backport_tracks:
   - track/1.10
+  - track/2.0


### PR DESCRIPTION
This PR adds the `track/2.0` branch to the default branches for the backport PR automation.