### PR TITLE
chore: update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @canonical/kubeflow
+*       @canonical/mlops


### PR DESCRIPTION
This PR updates the `CODEOWNERS` file to use correct _MLOps_ group.